### PR TITLE
Fixed bug in findCsrfToken() where the regex wouldn’t match the <meta> tag

### DIFF
--- a/FetLife.php
+++ b/FetLife.php
@@ -217,7 +217,7 @@ class FetLifeConnection extends FetLife {
      */
     private function findCsrfToken ($str) {
         $matches = array();
-        preg_match('/<meta name="csrf-token" content="([+a-zA-Z0-9&#;=-]+)"\/>/', $str, $matches);
+        preg_match('/<meta name="csrf-token" content="([^"]+)"/', $str, $matches);
         // Decode numeric HTML entities if there are any. See also:
         //     http://www.php.net/manual/en/function.html-entity-decode.php#104617
         $r = preg_replace_callback(


### PR DESCRIPTION
I was having pretty bad errors upon calling $fl->`logIn()`, it would just give me the following stack trace:

```
PHP Notice:  Undefined offset: 1 in /projects/php/fl/libFetLife/FetLife.php on line 230
PHP Stack trace:
PHP   1. {main}() /projects/php/fl/fl.php:0
PHP   2. FetLifeUser->logIn() /projects/php/fl/fl.php:9
PHP   3. FetLifeConnection->logIn() /projects/php/fl/libFetLife/FetLife.php:263
PHP   4. FetLifeConnection->findCsrfToken() /projects/php/fl/libFetLife/FetLife.php:116

Notice: Undefined offset: 1 in /projects/php/fl/libFetLife/FetLife.php on line 230

Call Stack:
    0.0030     366320   1. {main}() /projects/php/fl/fl.php:0
    0.0168     629808   2. FetLifeUser->logIn() /projects/php/fl/fl.php:9
    0.0168     629808   3. FetLifeConnection->logIn() /projects/php/fl/libFetLife/FetLife.php:263
    1.9926     643008   4. FetLifeConnection->findCsrfToken() /projects/php/fl/libFetLife/FetLife.php:116
```

I fixed this for myself by slightly changing the regular expression in `findCsrfToken()`. It works for me now.
