### PR TITLE
Fix broken login (again)

### DIFF
--- a/FetLife.php
+++ b/FetLife.php
@@ -124,6 +124,7 @@ class FetLifeConnection extends FetLife {
         $post_data = http_build_query(array(
             'user[login]' => $this->usr->nickname,
             'user[password]' => $this->usr->password,
+            'user[otp_attempt]' => 'step_1',
             'authenticity_token' => $this->csrf_token,
             'utf8' => '✓'
         ));


### PR DESCRIPTION
libFetLife appears to have broken again. The login POST was returning a 500 error from the server.

Inspection of the process in browser shows the addition of a new parameter to the POST data - otp_attempt, which should be set to step_1. Interestingly, this suggests that FL are working on two factor authentication or similar.
